### PR TITLE
README: Fix typo, markdownlint, punctuation, backticks and steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # trace-xyyx
+
 Simple C Tracing example, for x86 and raspberry pi pico
 
-Steps to build it it. 
+Steps to build it.
 
 `export PICO_SDK_FETCH_FROM_GIT=true` or `export PICO_SDK_PATH = <path>`
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # trace-xyyx
 
-Simple C Tracing example, for x86 and raspberry pi pico
+Simple C Tracing example, for x86 and raspberry pi pico.
 
-Steps to build it.
+Steps to build it:
 
 `export PICO_SDK_FETCH_FROM_GIT=true` or `export PICO_SDK_PATH = <path>`
 
@@ -14,9 +14,9 @@ Steps to build it.
 
 `make -j 8`
 
-then copy trace-xyyx.uf2 to your pico-pi for fun!
+then copy `trace-xyyx.uf2` to your pico-pi for fun!
 
-To add a trace point, edit the `metadata` file. Then run `xxd -i metadata > metadata.h` to override the metadata.h file.
+To add a trace point, edit the `metadata` file. Then run `xxd -i metadata > metadata.h` to override the `metadata.h` file.
 
 This needs more work, it is still non-functional.
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,12 @@ Simple C Tracing example, for x86 and raspberry pi pico.
 
 Steps to build it:
 
-`export PICO_SDK_FETCH_FROM_GIT=true` or `export PICO_SDK_PATH = <path>`
-
-`mkdir build`
-
-`cd build`
-
-`cmake ..`
-
-`make -j 8`
-
-then copy `trace-xyyx.uf2` to your pico-pi for fun!
+1. `export PICO_SDK_FETCH_FROM_GIT=true` or `export PICO_SDK_PATH = <path>`
+1. `mkdir build`
+1. `cd build`
+1. `cmake ..`
+1. `make -j 8`
+1. then copy `trace-xyyx.uf2` to your pico-pi for fun!
 
 To add a trace point, edit the `metadata` file. Then run `xxd -i metadata > metadata.h` to override the `metadata.h` file.
 


### PR DESCRIPTION
This PR is made of 3 step-wise (yet simple) commits, with slightly detailed commit messages:

1. Fix typo and markdownlint issues in VSCode.
2. Fix punctuation and few missing backticks.
3. Make the build steps a numbered steps list.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>